### PR TITLE
Feature/zip dependencies

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -19,7 +19,7 @@ var archiver = require('archiver');
 //This is not ideal but should work for now to seperate deploy vs lambda dependencies
 var deployDependencies = ["archiver", "async", "aws-sdk", "chalk",
     "debug", "lodash", "tmp", "yargs"];
-var allDependencies = Object.keys(require('./package.json').dependencies);
+var allDependencies = Object.keys(require('../../package.json').dependencies);
 var lambdaDependencies = _.difference(allDependencies, deployDependencies);
 
 aws.config.update({
@@ -112,7 +112,8 @@ function createLambda(role, llamaFile, done) {
 
   var lambdaPath = path.join(__dirname, '../../lambda/index.js');
   var tmpf = tmp.fileSync();
-  archive.pipe(fs.createWriteStream(tmpf.name));
+  var tmpfStream = fs.createWriteStream(tmpf.name);
+  archive.pipe(tmpfStream);
   archive.append(fs.readFileSync(lambdaPath), { name: 'index.js' });
   if (llamaFile) {
     debug('Adding real Llamafile to lambda zip');
@@ -125,46 +126,51 @@ function createLambda(role, llamaFile, done) {
   lambdaDependencies.forEach( function (moduleName){
     archive.directory('./node_modules/' + moduleName, 'node_modules/'+ moduleName);
   })
-  archive.finalize();
-
+  
   archive.on('error', function(err) {
     console.log('error');
     throw err;
   });
 
-  debug('Zip file written to %s', tmpf.name);
-
-  var params = {
-    Code: {
-      ZipFile: fs.readFileSync(tmpf.name)
-    },
-    FunctionName: 'chaosLlama',
-    Handler: 'index.handler',
-    Role: role,
-    Runtime: 'nodejs',
-    Description: 'Chaos Llama - http://llamajs.com',
-    MemorySize: 128,
-    Publish: true,
-    Timeout: 300
-  };
-
-  lambda.createFunction(params, function(err, data) {
-    if (err) {
-      if (err.code === 'ResourceConflictException' && err.statusCode === 409) {
-        console.log('Updating existing lambda definition');
-        lambda.updateFunctionCode({
-          FunctionName: 'chaosLlama',
-          Publish: true,
+  tmpfStream.on('finish', function() {
+      var params = {
+      Code: {
           ZipFile: fs.readFileSync(tmpf.name)
-        }, done);
+        },
+        FunctionName: 'chaosLlama',
+        Handler: 'index.handler',
+        Role: role,
+        Runtime: 'nodejs',
+        Description: 'Chaos Llama - http://llamajs.com',
+        MemorySize: 128,
+        Publish: true,
+        Timeout: 300
+      };
+
+    lambda.createFunction(params, function(err, data) {
+      if (err) {
+        if (err.code === 'ResourceConflictException' && err.statusCode === 409) {
+          console.log('Updating existing lambda definition');
+          lambda.updateFunctionCode({
+            FunctionName: 'chaosLlama',
+            Publish: true,
+            ZipFile: fs.readFileSync(tmpf.name)
+          }, done);
+        } else {
+          return done(err, null);
+        }
       } else {
-        return done(err, null);
+        return done(null, data);
       }
-    } else {
-      return done(null, data);
-    }
+    });
   });
+  archive.on('close', function(){
+    tmpfStream.close();
+  })
+  archive.finalize();
+  debug('Zip file written to %s', tmpf.name);
 }
+
 function configSchedule(interval, functionArn, done) {
   A.waterfall(
     [

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -9,11 +9,18 @@ var aws = require('aws-sdk');
 var chalk = require('chalk');
 var fs = require('fs');
 var debug = require('debug')('command:deploy');
-var Zip = require('adm-zip');
 var path = require('path');
 var tmp = require('tmp');
 var util = require('util');
 var A = require('async');
+var _ = require('lodash');
+var archiver = require('archiver');
+
+//This is not ideal but should work for now to seperate deploy vs lambda dependencies
+var deployDependencies = ["archiver", "async", "aws-sdk", "chalk",
+    "debug", "lodash", "tmp", "yargs"];
+var allDependencies = Object.keys(require('./package.json').dependencies);
+var lambdaDependencies = _.difference(allDependencies, deployDependencies);
 
 aws.config.update({
   region: process.env.AWS_REGION || 'eu-west-1'
@@ -101,20 +108,30 @@ function deploy(yargs, argv) {
 function createLambda(role, llamaFile, done) {
   var lambda = new aws.Lambda({apiVersion: '2015-03-31'});
 
-  var zip = new Zip();
+  var archive = archiver.create('zip', {}); 
 
   var lambdaPath = path.join(__dirname, '../../lambda/index.js');
   var tmpf = tmp.fileSync();
-  zip.addFile('index.js', fs.readFileSync(lambdaPath), '');
+  archive.pipe(fs.createWriteStream(tmpf.name));
+  archive.append(fs.readFileSync(lambdaPath), { name: 'index.js' });
   if (llamaFile) {
     debug('Adding real Llamafile to lambda zip');
     llamaFile.region = process.env.AWS_REGION; // FIXME
-    zip.addFile('config.json', new Buffer(JSON.stringify(llamaFile)));
+    archive.append(new Buffer(JSON.stringify(llamaFile)), { name: 'config.json' });
   } else {
     debug('Adding a stub Llamafile to lambda zip');
-    zip.addFile('config.json', new Buffer(JSON.stringify({enableForASGs: []})));
+    archive.append(new Buffer(JSON.stringify({enableForASGs: []})), { name: 'config.json' });
   }
-  zip.writeZip(tmpf.name);
+  lambdaDependencies.forEach( function (moduleName){
+    archive.directory('./node_modules/' + moduleName, 'node_modules/'+ moduleName);
+  })
+  archive.finalize();
+
+  archive.on('error', function(err) {
+    console.log('error');
+    throw err;
+  });
+
   debug('Zip file written to %s', tmpf.name);
 
   var params = {

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
   },
   "homepage": "https://github.com/hassy/llama-cli#readme",
   "dependencies": {
-    "adm-zip": "0.4.7",
+    "archiver": "^1.0.0",
     "async": "1.5.2",
     "aws-sdk": "2.2.40",
     "chalk": "1.1.1",
     "debug": "2.2.0",
     "lodash": "4.6.1",
+    "request-promise": "^3.0.0",
     "tmp": "0.0.28",
     "yargs": "4.2.0"
   }


### PR DESCRIPTION
This will allow node_module directories  to be added to the lambda code zip file. Uses a hard coded list of what the deploy dependencies are to be able to add everything else to the zip. Not ideal but if you have any recommendations on a better way I would love to hear it :) 

Added request-promise to the package.json as a way to test that it gets included. I intend to use request-promise in the slack notification feature which I will work on next if there are no complaints.