### PR TITLE
Adding datetime to Statement id to fix the `ResourceConflictException…

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -192,7 +192,7 @@ function addLambdaPermission(context, next) {
   // TODO: Remove the statement or make unique with Date.now
   var params = {
     FunctionName: 'chaosLlama',
-    StatementId: 'chaosLlamaStatement',
+    StatementId: 'chaosLlamaStatement' + '_' + Date.now(),
     Action: 'lambda:InvokeFunction',
     Principal: 'events.amazonaws.com',
     SourceArn: context.RuleArn


### PR DESCRIPTION
…: The statement id (chaosLlamaStatement) provided already exists.` issue